### PR TITLE
Handle nullable param type where default isn't null

### DIFF
--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -173,12 +173,12 @@ class FileParser
                             $type = strpos($type, '\\') === 0 ? substr($type, 1) : $type;
                         }
 
-                        if ($method->returnType instanceof NullableType) {
+                        if ($param->type instanceof NullableType) {
                             $type .= '|null';
                         }
 
                         if (
-                            !$method->returnType instanceof NullableType &&
+                            !$param->type instanceof NullableType &&
                             property_exists($param, 'default') &&
                             $param->default instanceof Expr &&
                             property_exists($param->default, 'name') &&

--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -173,7 +173,13 @@ class FileParser
                             $type = strpos($type, '\\') === 0 ? substr($type, 1) : $type;
                         }
 
-                        if (property_exists($param, 'default') &&
+                        if ($method->returnType instanceof NullableType) {
+                            $type .= '|null';
+                        }
+
+                        if (
+                            !$method->returnType instanceof NullableType &&
+                            property_exists($param, 'default') &&
                             $param->default instanceof Expr &&
                             property_exists($param->default, 'name') &&
                             property_exists($param->default->name, 'parts') &&


### PR DESCRIPTION
On https://github.com/D3R/soho-products output using master is

```
 php vendor/bin/phpdoccheck --directory=./src                                                                                                                           12:04:51

PHP Docblock Checker by Dan Cryer (https://www.dancryer.com)

...W......................W....

Checked 31 files in 0.18 seconds.
31 Passed / 0 Errors / 4 Warnings / 0 Info


WARNING  Soho\Products\Base\Tools\Maths\Convert::cmToInches - @param $round (int|null)  does not match method signature (int).
WARNING  Soho\Products\Base\Tools\Maths\Convert::cmToFeetAndInches - @param $round (int|null)  does not match method signature (int).
WARNING  Soho\Products\Base\Tools\Maths\Convert::kilogramsToPounds - @param $round (int|null)  does not match method signature (int).
WARNING  Soho\Products\Base\Model\Stock::updateStockRecord - @param $storeId (string|null)  does not match method signature (string).
```

But using this branch it is 

```
 php vendor/bin/phpdoccheck --directory=./src                                                                                                                           12:05:45

PHP Docblock Checker by Dan Cryer (https://www.dancryer.com)

...............................

Checked 31 files in 0.19 seconds.
31 Passed / 0 Errors / 0 Warnings / 0 Info
```
