### PR TITLE
Support null return or null in union

### DIFF
--- a/src/Check/ParamCheck.php
+++ b/src/Check/ParamCheck.php
@@ -52,10 +52,7 @@ class ParamCheck extends Check
                     }
                 }
 
-                if (
-                    $paramType->isNullable() !== $docBlockType->isNullable()
-                    || $paramType->isVariadic() !== $docBlockType->isVariadic()
-                ) {
+                if ($paramType->isVariadic() !== $docBlockType->isVariadic()) {
                     $this->fileStatus->add(
                         new ParamMismatchWarning(
                             $file->getFileName(),

--- a/src/Check/ReturnCheck.php
+++ b/src/Check/ReturnCheck.php
@@ -51,19 +51,6 @@ class ReturnCheck extends Check
                     continue 2;
                 }
             }
-
-            if ($methodTypes->isNullable() !== $docBlockTypes->isNullable()) {
-                $this->fileStatus->add(
-                    new ReturnMismatchWarning(
-                        $file->getFileName(),
-                        $name,
-                        $method->getLine(),
-                        $name,
-                        $methodTypes->toString(),
-                        $docBlockTypes->toString(),
-                    )
-                );
-            }
         }
     }
 

--- a/src/Code/AbstractType.php
+++ b/src/Code/AbstractType.php
@@ -17,9 +17,6 @@ abstract class AbstractType extends AbstractCode
     /** @var array */
     protected $types = [];
 
-    /** @var bool */
-    protected $nullable = false;
-
     /**
      * Create new instance using array data
      *
@@ -31,33 +28,12 @@ abstract class AbstractType extends AbstractCode
     {
         /** @var AbstractType $method */
         $method = parent::fromArray($data);
-        $method->setNullable($data['nullable']);
 
         foreach ($data['types'] as $type) {
             $method->addType($type);
         }
 
         return $method;
-    }
-
-    /**
-     * @param bool $bool
-     * @return self
-     */
-    public function setNullable(bool $bool): self
-    {
-        $this->nullable = $bool;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     * @author Neil Brayfield <neil@d3r.com>
-     */
-    public function isNullable(): bool
-    {
-        return $this->nullable;
     }
 
     /**
@@ -99,7 +75,7 @@ abstract class AbstractType extends AbstractCode
      */
     public function __toString()
     {
-        return implode('|', $this->types) . ($this->isNullable() ? '|null' : '');
+        return implode('|', $this->types);
     }
 
     /**
@@ -123,10 +99,6 @@ abstract class AbstractType extends AbstractCode
         $types = explode('|', $type);
 
         foreach ($types as $type) {
-            if ($type === 'null') {
-                $this->setNullable(true);
-                continue;
-            }
             $this->addType($type);
         }
 
@@ -161,7 +133,6 @@ abstract class AbstractType extends AbstractCode
         $base = parent::jsonSerialize();
 
         return array_merge($base, [
-            'nullable' => $this->nullable,
             'types' => $this->types,
         ]);
     }

--- a/src/Command/CheckerCommand.php
+++ b/src/Command/CheckerCommand.php
@@ -160,7 +160,7 @@ class CheckerCommand extends Command
 
         if ($config->isVerbose()) {
             $output->writeln('');
-            $output->writeln('PHP Docblock Checker <fg=blue>by Dan Cryer (https://www.dancryer.com)</>');
+            $output->writeln('PHP Docblock Checker');
             $output->writeln('');
         }
 

--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -150,7 +150,7 @@ class FileParser
                     if ($type instanceof NullableType) {
                         $returnType
                             ->addType($type->type->toString())
-                            ->setNullable(true);
+                            ->addType('null');
                     } elseif ($type instanceof UnionType) {
                         foreach ($type->types as $toAdd) {
                             $returnType->addType($toAdd->toString());
@@ -173,7 +173,7 @@ class FileParser
                         if ($type instanceof NullableType) {
                             $paramType
                                 ->addType($type->type->toString())
-                                ->setNullable(true);
+                                ->addType('null');
                         } elseif ($type instanceof UnionType) {
                             foreach ($type->types as $toAdd) {
                                 $paramType->addType($toAdd->toString());
@@ -189,7 +189,7 @@ class FileParser
                             property_exists($param->default->name, 'parts') &&
                             'null' === $param->default->name->parts[0]
                         ) {
-                            $paramType->setNullable(true);
+                            $paramType->addType('null');
                         }
 
                         $name = null;


### PR DESCRIPTION
Makes the below supported by thr checker.

```
/**
 * @return null
 */
public function testOnlyNullReturn(): null
{
    return null;
}

/**
 * @param DateTime|null|int $dateTime
 */
public function testNullParam(DateTime|null|int $dateTime = null): void
{}

/**
 * @return \DateTime|int|null
 */
public function testNullReturn(): DateTime|int|null
{
    return 0;
}
```

As currently the above fail the check with the below errors, and with these changes they pass.

```
WARNING  PhpDocBlockChecker\Test\Test::testNullParam - @param $dateTime (DateTime|int|null) does not match method signature DateTime|null|int|null.
WARNING  PhpDocBlockChecker\Test\Test::testOnlyNullReturn - @return |null does not match method signature null.
WARNING  PhpDocBlockChecker\Test\Test::testNullReturn - @return \DateTime|int|null does not match method signature DateTime|int|null.
```
