### PR TITLE
Upgrade actions/checkout to 7.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         version: ['8.0', '8.2', '8.3', '8.4']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:


### PR DESCRIPTION
Removes this warning
<img width="1136" height="190" alt="Screenshot 2026-07-13 at 9 48 59 am" src="https://github.com/user-attachments/assets/8623c612-5ab7-4b1e-ae0f-a09c0af43bd6" />
